### PR TITLE
implement automatic heapdumps when usage is above threshold.

### DIFF
--- a/adaptive_test.go
+++ b/adaptive_test.go
@@ -11,18 +11,18 @@ func TestAdaptivePolicy(t *testing.T) {
 	clk := clock.NewMock()
 	Clock = clk
 
-	p, err := NewAdaptivePolicy(0.5)(limit)
+	p, err := NewAdaptivePolicy(0.5)(limit64MiB)
 	require.NoError(t, err)
 
 	// at zero; next = 50%.
 	next := p.Evaluate(UtilizationSystem, 0)
-	require.EqualValues(t, limit/2, next)
+	require.EqualValues(t, limit64MiB/2, next)
 
 	// at half; next = 75%.
-	next = p.Evaluate(UtilizationSystem, limit/2)
-	require.EqualValues(t, 3*(limit/4), next)
+	next = p.Evaluate(UtilizationSystem, limit64MiB/2)
+	require.EqualValues(t, 3*(limit64MiB/4), next)
 
-	// at limit.
-	next = p.Evaluate(UtilizationSystem, limit)
-	require.EqualValues(t, limit, next)
+	// at limit64MiB.
+	next = p.Evaluate(UtilizationSystem, limit64MiB)
+	require.EqualValues(t, limit64MiB, next)
 }

--- a/adaptive_test.go
+++ b/adaptive_test.go
@@ -22,7 +22,7 @@ func TestAdaptivePolicy(t *testing.T) {
 	next = p.Evaluate(UtilizationSystem, limit64MiB/2)
 	require.EqualValues(t, 3*(limit64MiB/4), next)
 
-	// at limit64MiB.
+	// at limit.
 	next = p.Evaluate(UtilizationSystem, limit64MiB)
 	require.EqualValues(t, limit64MiB, next)
 }

--- a/watchdog_linux.go
+++ b/watchdog_linux.go
@@ -59,7 +59,7 @@ func CgroupDriven(frequency time.Duration, policyCtor PolicyCtor) (err error, st
 	}
 
 	_watchdog.wg.Add(1)
-	go pollingWatchdog(policy, frequency, func() (uint64, error) {
+	go pollingWatchdog(policy, frequency, limit, func() (uint64, error) {
 		stat, err := cgroup.Stat()
 		if err != nil {
 			return 0, err

--- a/watermarks.go
+++ b/watermarks.go
@@ -29,7 +29,7 @@ type watermarkPolicy struct {
 var _ Policy = (*watermarkPolicy)(nil)
 
 func (w *watermarkPolicy) Evaluate(_ UtilizationType, used uint64) (next uint64) {
-	Logger.Debugf("watermark policy: evaluating; utilization: %d/%d (used/limit64MiB)", used, w.limit)
+	Logger.Debugf("watermark policy: evaluating; utilization: %d/%d (used/limit)", used, w.limit)
 	var i int
 	for ; i < len(w.thresholds); i++ {
 		t := w.thresholds[i]

--- a/watermarks.go
+++ b/watermarks.go
@@ -29,7 +29,7 @@ type watermarkPolicy struct {
 var _ Policy = (*watermarkPolicy)(nil)
 
 func (w *watermarkPolicy) Evaluate(_ UtilizationType, used uint64) (next uint64) {
-	Logger.Debugf("watermark policy: evaluating; utilization: %d/%d (used/limit)", used, w.limit)
+	Logger.Debugf("watermark policy: evaluating; utilization: %d/%d (used/limit64MiB)", used, w.limit)
 	var i int
 	for ; i < len(w.thresholds); i++ {
 		t := w.thresholds[i]

--- a/watermarks_test.go
+++ b/watermarks_test.go
@@ -12,7 +12,7 @@ var (
 	thresholds = func() []uint64 {
 		var ret []uint64
 		for _, w := range watermarks {
-			ret = append(ret, uint64(float64(limit)*w))
+			ret = append(ret, uint64(float64(limit64MiB)*w))
 		}
 		return ret
 	}()
@@ -22,7 +22,7 @@ func TestProgressiveWatermarks(t *testing.T) {
 	clk := clock.NewMock()
 	Clock = clk
 
-	p, err := NewWatermarkPolicy(watermarks...)(limit)
+	p, err := NewWatermarkPolicy(watermarks...)(limit64MiB)
 	require.NoError(t, err)
 
 	// at zero
@@ -30,25 +30,25 @@ func TestProgressiveWatermarks(t *testing.T) {
 	require.EqualValues(t, thresholds[0], next)
 
 	// before the watermark.
-	next = p.Evaluate(UtilizationSystem, uint64(float64(limit)*watermarks[0])-1)
+	next = p.Evaluate(UtilizationSystem, uint64(float64(limit64MiB)*watermarks[0])-1)
 	require.EqualValues(t, thresholds[0], next)
 
 	// exactly at the watermark; gives us the next watermark, as the watchdodg would've
 	// taken care of triggering the first watermark.
-	next = p.Evaluate(UtilizationSystem, uint64(float64(limit)*watermarks[0]))
+	next = p.Evaluate(UtilizationSystem, uint64(float64(limit64MiB)*watermarks[0]))
 	require.EqualValues(t, thresholds[1], next)
 
 	// after the watermark gives us the next watermark.
-	next = p.Evaluate(UtilizationSystem, uint64(float64(limit)*watermarks[0])+1)
+	next = p.Evaluate(UtilizationSystem, uint64(float64(limit64MiB)*watermarks[0])+1)
 	require.EqualValues(t, thresholds[1], next)
 
 	// last watermark; disable the policy.
-	next = p.Evaluate(UtilizationSystem, uint64(float64(limit)*watermarks[2]))
+	next = p.Evaluate(UtilizationSystem, uint64(float64(limit64MiB)*watermarks[2]))
 	require.EqualValues(t, PolicyTempDisabled, next)
 
-	next = p.Evaluate(UtilizationSystem, uint64(float64(limit)*watermarks[2]+1))
+	next = p.Evaluate(UtilizationSystem, uint64(float64(limit64MiB)*watermarks[2]+1))
 	require.EqualValues(t, PolicyTempDisabled, next)
 
-	next = p.Evaluate(UtilizationSystem, limit)
+	next = p.Evaluate(UtilizationSystem, limit64MiB)
 	require.EqualValues(t, PolicyTempDisabled, next)
 }


### PR DESCRIPTION
A heapdump will be captured when the usage trespasses the threshold. Staying above the threshold won't trigger another heapdump. If the usage goes down, then back up, that is considered another
"episode" to be captured in a heapdump.

This feature is driven by three parameters:

* HeapdumpDir: the directory where the watchdog will write the heapdump. It will be created if it doesn't exist upon initialization. An error when creating the dir will not prevent heapdog initialization; it will just disable the heapdump capture feature.

  If zero-valued, the feature is disabled. Heapdumps will be written to path: `<HeapdumpDir>/<RFC3339Nano formatted timestamp>.heap`.

* HeapdumpMaxCaptures: sets the maximum amount of heapdumps a process will generate. This limits the amount of episodes that will be captured, in case the utilization climbs repeatedly over the threshold. By default, it is 10.

* HeapdumpThreshold: sets the utilization threshold that will trigger a heap dump to be taken automatically. A zero value disables this feature. By default, it is disabled.