### PR TITLE
add a RegisterNotifee function to register notifees, deprecate NotifyGC

### DIFF
--- a/watchdog_test.go
+++ b/watchdog_test.go
@@ -153,7 +153,7 @@ func TestSystemDriven_Isolated(t *testing.T) {
 	NotifyGC = func() {
 		notifyChDeprecated <- struct{}{}
 	}
-	RegisterNotifee(func() {
+	RegisterNotifee("test notifee", func() {
 		notifyCh <- struct{}{}
 	})
 
@@ -161,7 +161,7 @@ func TestSystemDriven_Isolated(t *testing.T) {
 	clk.Add(5 * time.Second)
 	time.Sleep(200 * time.Millisecond)
 	require.Len(t, notifyChDeprecated, 0) // no GC has taken place.
-	require.Len(t, notifyCh, 0) // no GC has taken place.
+	require.Len(t, notifyCh, 0)           // no GC has taken place.
 
 	// second tick; used = just over 50%; will trigger GC.
 	actualUsed = (limit64MiB / 2) + 1

--- a/watchdog_test.go
+++ b/watchdog_test.go
@@ -153,9 +153,10 @@ func TestSystemDriven_Isolated(t *testing.T) {
 	NotifyGC = func() {
 		notifyChDeprecated <- struct{}{}
 	}
-	RegisterNotifee("test notifee", func() {
+	unregister := RegisterNotifee(func() {
 		notifyCh <- struct{}{}
 	})
+	defer unregister()
 
 	// first tick; used = 0.
 	clk.Add(5 * time.Second)


### PR DESCRIPTION
As this is only deprecating (and not removing) `NotifyGC`, this will allow us to release this as v1.1.0 in a semver-compatible way.